### PR TITLE
Add aliases support for python 2.7

### DIFF
--- a/viper/__main__.py
+++ b/viper/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 import viper
+from viper.backports import AliasedSubParsersAction
 from viper.commands.bite import BiteCommand
 from viper.commands.freeze import FreezeCommand
 
@@ -35,8 +36,11 @@ def main(args=None):
     parser = argparse.ArgumentParser(
         description="Packaging made easier than it needs to be."
     )
-    parser = _optional_commands(parser)
 
+    # Support aliases for python 2.7
+    parser.register('action', 'parsers', AliasedSubParsersAction)
+
+    parser = _optional_commands(parser)
     parser_commands = parser.add_subparsers(
         title="Commands",
         dest="commands"

--- a/viper/backports.py
+++ b/viper/backports.py
@@ -1,0 +1,33 @@
+import argparse
+
+
+class AliasedSubParsersAction(argparse._SubParsersAction):
+
+    class _AliasedPseudoAction(argparse.Action):
+        def __init__(self, name, aliases, help):
+            dest = name
+            if aliases:
+                dest += ' (%s)' % ','.join(aliases)
+            sup = super(AliasedSubParsersAction._AliasedPseudoAction, self)
+            sup.__init__(option_strings=[], dest=dest, help=help)
+
+    def add_parser(self, name, **kwargs):
+        if 'aliases' in kwargs:
+            aliases = kwargs['aliases']
+            del kwargs['aliases']
+        else:
+            aliases = []
+
+        parser = super(AliasedSubParsersAction, self).add_parser(name, **kwargs)
+
+        # Make the aliases work.
+        for alias in aliases:
+            self._name_parser_map[alias] = parser
+        # Make the help text reflect them, first removing old help entry.
+        if 'help' in kwargs:
+            help = kwargs.pop('help')
+            self._choices_actions.pop()
+            pseudo_action = self._AliasedPseudoAction(name, aliases, help)
+            self._choices_actions.append(pseudo_action)
+
+        return parser


### PR DESCRIPTION
Aliases are not available in the python 2.7 version of argparse.